### PR TITLE
Add check for events with not subscribers. I.e. manually generated events

### DIFF
--- a/alerta.rb
+++ b/alerta.rb
@@ -40,6 +40,7 @@ class Alerta < Sensu::Handler
     hostname = Socket.gethostname
 
     environment = @event['check']['environment'] || 'Production'
+    subscribers = @event['check']['subscribers'] || []
 
     payload = {
       "origin" => "sensu/#{hostname}",
@@ -57,7 +58,7 @@ class Alerta < Sensu::Handler
       "value" => "",
       "type" => "sensuAlert",
       "attributes" => {
-        "subscribers" => "#{@event['check']['subscribers'].join(",")}",
+        "subscribers" => "subscribers.join(",")}",
         "thresholdInfo" => "#{@event['action']}: #{@event['check']['command']}"
       },
       "rawData" => "#{@event.to_json}"

--- a/alerta.rb
+++ b/alerta.rb
@@ -58,7 +58,7 @@ class Alerta < Sensu::Handler
       "value" => "",
       "type" => "sensuAlert",
       "attributes" => {
-        "subscribers" => "subscribers.join(",")}",
+        "subscribers" => "#{subscribers.join(",")}",
         "thresholdInfo" => "#{@event['action']}: #{@event['check']['command']}"
       },
       "rawData" => "#{@event.to_json}"


### PR DESCRIPTION
While doing: https://sensuapp.org/docs/0.21/clients#client-socket-input, the subscribers key of the check is not there and that raises a `undefined method `join' for nil:NilClass (NoMethodError)`. I am not a Ruby developer so I am unsure this is the proper way to check key presence.