### PR TITLE
Remap to indeterminate so alerta core would transition status based on severity

### DIFF
--- a/alerta.rb
+++ b/alerta.rb
@@ -27,7 +27,7 @@ class Alerta < Sensu::Handler
       when 2
         "critical"
       else
-        "unknown"
+        "indeterminate"
     end
   end
 


### PR DESCRIPTION
As we've discussed on gitter, here's the PR to remap severity so that alerts would transition upon creation or any other lower alert severities.